### PR TITLE
Live address bar without showing terminal section groups

### DIFF
--- a/src/components/addressBar.js
+++ b/src/components/addressBar.js
@@ -20,10 +20,12 @@ export default class AddressBar extends React.Component {
 
     static getDerivedStateFromProps(nextProps, prevState) {
         let items = [];
+        let elements = []; // used for determining if the final item is a section/page. If it's not, only the notebook is shown
         const { selectedNav, onenote } = nextProps;
         for (let i = 0; i < selectedNav.length; i++) {
             const id = selectedNav[i];
             const element = onenote[id];
+            elements.push(element);
             items.push({
                 text: element.displayName || element.title,
                 key: id + "breadcrumb",
@@ -31,6 +33,18 @@ export default class AddressBar extends React.Component {
                 isCurrentItem: (i === selectedNav.length - 1)
             });
         }
+
+        // CAN BE REMOVED IF IT IS DESIRED THAT SECTION GROUPS ARE SHOWN AS THE LAST ITEMS IN THE ADDRESS BAR
+        if (elements.length > 1) {
+            const lastIndex = elements.length - 1;
+            if (elements[lastIndex].hasOwnProperty("title") || elements[lastIndex].hasOwnProperty("pages")) { // the last item is a section/page
+                return { ...prevState, items };
+            } else {
+                return { ...prevState, "items": items.slice(0, 1)};
+            }
+        }
+        // END OF POSSIBLE REMOVAL
+
         return { ...prevState, items };
     }
 
@@ -43,7 +57,7 @@ export default class AddressBar extends React.Component {
             <Breadcrumb
                 items={this.state.items}
                 // Returning undefined to OnReduceData tells the breadcrumb not to shrink
-                onReduceData={ this.returnUndefined }
+                onReduceData={this.returnUndefined}
                 maxDisplayedItems={4}
             />
         );


### PR DESCRIPTION
Per https://github.com/dalyIsaac/onenote-markdown/pull/43#issuecomment-380779268 section groups are no longer shown if they're the last item in the address bar: 
![2018-04-13_00-07-24](https://user-images.githubusercontent.com/17995621/38676357-e49bcd76-3eae-11e8-8143-e05a86adb005.gif)
