### PR TITLE
Remove unneeded returns

### DIFF
--- a/src/page/reducer.test.ts
+++ b/src/page/reducer.test.ts
@@ -7,12 +7,12 @@ import {
   REPLACE_CONTENT,
   ReplaceContentAction,
 } from "./actions";
-import { Color, NEWLINE, PageContent, StatePages } from "./model";
+import { Color, NEWLINE, PageContent, PageContentMutable, StatePages } from "./model";
 import pageReducer from "./reducer";
 import { LF, LF_CONTENT, pageReducerTest } from "./tree/createNewPage.test";
 import { SENTINEL, SENTINEL_INDEX } from "./tree/tree";
 
-export const getStartPage = (): PageContent => ({
+export const getStartPage = (): PageContentMutable => ({
   buffers: [
     {
       isReadOnly: true,

--- a/src/page/reducer.ts
+++ b/src/page/reducer.ts
@@ -63,14 +63,14 @@ export default function pageReducer(
         buffers: [...state[insertAction.pageId].buffers],
         nodes: [...state[insertAction.pageId].nodes],
       };
-      newPage = insertContent(
+      insertContent(
         extractedPage as PageContentMutable,
         { content: insertAction.content, offset: insertAction.offset },
         MAX_BUFFER_LENGTH,
       );
       newState = {
         ...state,
-        [insertAction.pageId]: newPage,
+        [insertAction.pageId]: extractedPage,
       };
       return newState;
     case DELETE_CONTENT:

--- a/src/page/reducer.ts
+++ b/src/page/reducer.ts
@@ -80,13 +80,13 @@ export default function pageReducer(
         buffers: [...state[deleteAction.pageId].buffers],
         nodes: [...state[deleteAction.pageId].nodes],
       };
-      newPage = deleteContent(extractedPage as PageContentMutable, {
+      deleteContent(extractedPage as PageContentMutable, {
         startOffset: deleteAction.startOffset,
         endOffset: deleteAction.endOffset,
       });
       newState = {
         ...state,
-        [deleteAction.pageId]: newPage,
+        [deleteAction.pageId]: extractedPage,
       };
       return newState;
     case REPLACE_CONTENT:
@@ -96,15 +96,12 @@ export default function pageReducer(
         buffers: [...state[replaceAction.pageId].buffers],
         nodes: [...state[replaceAction.pageId].nodes],
       };
-      const pageAfterDelete = deleteContent(
+      deleteContent(extractedPage as PageContentMutable, {
+        startOffset: replaceAction.startOffset,
+        endOffset: replaceAction.endOffset,
+      });
+      insertContent(
         extractedPage as PageContentMutable,
-        {
-          startOffset: replaceAction.startOffset,
-          endOffset: replaceAction.endOffset,
-        },
-      );
-      const pageAfterInsert = insertContent(
-        pageAfterDelete,
         {
           content: replaceAction.content,
           offset: replaceAction.startOffset,
@@ -113,7 +110,7 @@ export default function pageReducer(
       );
       newState = {
         ...state,
-        [replaceAction.pageId]: pageAfterInsert,
+        [replaceAction.pageId]: extractedPage,
       };
       return newState;
     default:

--- a/src/page/tree/delete.test.ts
+++ b/src/page/tree/delete.test.ts
@@ -1697,11 +1697,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 5,
             endOffset: 7,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 1a: Test 2", () => {
@@ -1789,11 +1789,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 0,
             endOffset: 2,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 1a: Test 3", () => {
@@ -1881,11 +1881,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 0,
             endOffset: 5,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 1a: Test 4", () => {
@@ -1973,11 +1973,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 2,
             endOffset: 7,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
       });
 
@@ -2067,11 +2067,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 0,
             endOffset: 4,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 1b: Test 2", () => {
@@ -2159,11 +2159,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 2,
             endOffset: 6,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 1b: Test 3", () => {
@@ -2251,11 +2251,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 2,
             endOffset: 5,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 1b: Test 4", () => {
@@ -2343,11 +2343,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 2,
             endOffset: 4,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 1b: Test 5", () => {
@@ -2435,11 +2435,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 5,
             endOffset: 6,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 1b: Test 6", () => {
@@ -2527,11 +2527,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 0,
             endOffset: 1,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
       });
 
@@ -2621,11 +2621,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 2,
             endOffset: 5,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 1c: Test 2", () => {
@@ -2713,11 +2713,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 3,
             endOffset: 5,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 1c: Test 3", () => {
@@ -2805,11 +2805,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 4,
             endOffset: 5,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 1c: Test 4", () => {
@@ -2897,11 +2897,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 5,
             endOffset: 6,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 1c: Test 5", () => {
@@ -2989,11 +2989,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 4,
             endOffset: 7,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 1c: Test 6", () => {
@@ -3081,11 +3081,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 6,
             endOffset: 7,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 1c: Test 7", () => {
@@ -3173,11 +3173,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 1,
             endOffset: 2,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
       });
 
@@ -3280,11 +3280,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 2,
             endOffset: 4,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 1d: Test 2", () => {
@@ -3385,11 +3385,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 3,
             endOffset: 4,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 1d: Test 3", () => {
@@ -3490,11 +3490,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 2,
             endOffset: 3,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 1d: Test 4", () => {
@@ -3595,11 +3595,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 4,
             endOffset: 6,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 1d: Test 5", () => {
@@ -3700,11 +3700,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 4,
             endOffset: 5,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 1d: Test 6", () => {
@@ -3805,11 +3805,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 6,
             endOffset: 8,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 1d: Test 7", () => {
@@ -3910,11 +3910,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 1,
             endOffset: 3,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
       });
     });
@@ -4100,11 +4100,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 66,
             endOffset: 94,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 2a: Test 2", () => {
@@ -4286,11 +4286,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 65,
             endOffset: 94,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 2a: Test 3", () => {
@@ -4472,11 +4472,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 0,
             endOffset: 94,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 2a: Test 4", () => {
@@ -4658,11 +4658,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 83,
             endOffset: 88,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 2a: Test 5", () => {
@@ -4844,11 +4844,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 83,
             endOffset: 127,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 2a: Test 6", () => {
@@ -5030,11 +5030,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 93,
             endOffset: 127,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 2a: Test 7", () => {
@@ -5216,11 +5216,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 0,
             endOffset: 80,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 2a: Test 8", () => {
@@ -5402,11 +5402,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 80,
             endOffset: 85,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
       });
 
@@ -5590,11 +5590,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 66,
             endOffset: 90,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 2b: Test 2", () => {
@@ -5772,11 +5772,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 0,
             endOffset: 84,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 2b: Test 3", () => {
@@ -5958,11 +5958,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 65,
             endOffset: 70,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 2b: Test 4", () => {
@@ -6144,11 +6144,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 87,
             endOffset: 90,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
       });
 
@@ -6332,11 +6332,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 31,
             endOffset: 66,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 2c: Test 2", () => {
@@ -6518,11 +6518,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 81,
             endOffset: 85,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 2c: Test 3", () => {
@@ -6704,11 +6704,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 84,
             endOffset: 87,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 2c: Test 4", () => {
@@ -6890,11 +6890,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 120,
             endOffset: 127,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 2c: Test 5", () => {
@@ -7076,11 +7076,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 90,
             endOffset: 127,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 2c: Test 6", () => {
@@ -7262,11 +7262,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 60,
             endOffset: 127,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
       });
 
@@ -7450,11 +7450,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 60,
             endOffset: 70,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 2d: Test 2", () => {
@@ -7636,11 +7636,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 30,
             endOffset: 70,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 2d: Test 3", () => {
@@ -7822,11 +7822,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 84,
             endOffset: 89,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 2d: Test 4", () => {
@@ -8008,11 +8008,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 81,
             endOffset: 86,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
 
         test("Scenario 2d: Test 5", () => {
@@ -8194,11 +8194,11 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const receivedPage = deleteContent(page, {
+          deleteContent(page, {
             startOffset: 89,
             endOffset: 100,
           });
-          expect(receivedPage).toStrictEqual(expectedPage);
+          expect(page).toStrictEqual(expectedPage)
         });
       });
     });

--- a/src/page/tree/delete.test.ts
+++ b/src/page/tree/delete.test.ts
@@ -1,4 +1,4 @@
-import { Color, NEWLINE, PageContent, PageContentMutable } from "../model";
+import { Color, NEWLINE, PageContentMutable } from "../model";
 import { getStartPage } from "../reducer.test";
 import { deleteContent, deleteNode } from "./delete";
 import { SENTINEL, SENTINEL_INDEX } from "./tree";
@@ -1613,7 +1613,7 @@ describe("page/tree/delete", () => {
     describe("Scenario 1", () => {
       describe("Scenario 1a: delete the content from an entire node", () => {
         test("Scenario 1a: Test 1", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -1655,7 +1655,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: 1,
             previouslyInsertedNodeOffset: 5,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -1701,11 +1701,11 @@ describe("page/tree/delete", () => {
             startOffset: 5,
             endOffset: 7,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 1a: Test 2", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -1747,7 +1747,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: 1,
             previouslyInsertedNodeOffset: 0,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -1793,11 +1793,11 @@ describe("page/tree/delete", () => {
             startOffset: 0,
             endOffset: 2,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 1a: Test 3", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -1839,7 +1839,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: 1,
             previouslyInsertedNodeOffset: 5,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -1885,11 +1885,11 @@ describe("page/tree/delete", () => {
             startOffset: 0,
             endOffset: 5,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 1a: Test 4", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -1931,7 +1931,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: 1,
             previouslyInsertedNodeOffset: 0,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -1977,13 +1977,13 @@ describe("page/tree/delete", () => {
             startOffset: 2,
             endOffset: 7,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
       });
 
       describe("Scenario 1b: delete from the start of a node to a point in the node", () => {
         test("Scenario 1b: Test 1", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -2025,7 +2025,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: 1,
             previouslyInsertedNodeOffset: 5,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -2071,11 +2071,11 @@ describe("page/tree/delete", () => {
             startOffset: 0,
             endOffset: 4,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 1b: Test 2", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -2117,7 +2117,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: 1,
             previouslyInsertedNodeOffset: 0,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -2163,11 +2163,11 @@ describe("page/tree/delete", () => {
             startOffset: 2,
             endOffset: 6,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 1b: Test 3", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -2209,7 +2209,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: 1,
             previouslyInsertedNodeOffset: 0,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -2255,11 +2255,11 @@ describe("page/tree/delete", () => {
             startOffset: 2,
             endOffset: 5,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 1b: Test 4", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -2301,7 +2301,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: 1,
             previouslyInsertedNodeOffset: 0,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -2347,11 +2347,11 @@ describe("page/tree/delete", () => {
             startOffset: 2,
             endOffset: 4,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 1b: Test 5", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -2393,7 +2393,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: 1,
             previouslyInsertedNodeOffset: 5,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -2439,11 +2439,11 @@ describe("page/tree/delete", () => {
             startOffset: 5,
             endOffset: 6,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 1b: Test 6", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -2485,7 +2485,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: 1,
             previouslyInsertedNodeOffset: 0,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -2531,13 +2531,13 @@ describe("page/tree/delete", () => {
             startOffset: 0,
             endOffset: 1,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
       });
 
       describe("Scenario 1c: delete from a point in a node to the end of the node", () => {
         test("Scenario 1c: Test 1", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -2579,7 +2579,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: 1,
             previouslyInsertedNodeOffset: 5,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -2625,11 +2625,11 @@ describe("page/tree/delete", () => {
             startOffset: 2,
             endOffset: 5,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 1c: Test 2", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -2671,7 +2671,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: 1,
             previouslyInsertedNodeOffset: 5,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -2717,11 +2717,11 @@ describe("page/tree/delete", () => {
             startOffset: 3,
             endOffset: 5,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 1c: Test 3", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -2763,7 +2763,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: 1,
             previouslyInsertedNodeOffset: 5,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -2809,11 +2809,11 @@ describe("page/tree/delete", () => {
             startOffset: 4,
             endOffset: 5,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 1c: Test 4", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndzef",
@@ -2855,7 +2855,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: 1,
             previouslyInsertedNodeOffset: 5,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndzef",
@@ -2901,11 +2901,11 @@ describe("page/tree/delete", () => {
             startOffset: 5,
             endOffset: 6,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 1c: Test 5", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -2947,7 +2947,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: 1,
             previouslyInsertedNodeOffset: 0,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -2993,11 +2993,11 @@ describe("page/tree/delete", () => {
             startOffset: 4,
             endOffset: 7,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 1c: Test 6", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -3039,7 +3039,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: 1,
             previouslyInsertedNodeOffset: 0,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -3085,11 +3085,11 @@ describe("page/tree/delete", () => {
             startOffset: 6,
             endOffset: 7,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 1c: Test 7", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -3131,7 +3131,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: 1,
             previouslyInsertedNodeOffset: 0,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -3177,13 +3177,13 @@ describe("page/tree/delete", () => {
             startOffset: 1,
             endOffset: 2,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
       });
 
       describe("Scenario 1d: delete from a point in a node to another point in the node", () => {
         test("Scenario 1d: Test 1", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -3225,7 +3225,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: 1,
             previouslyInsertedNodeOffset: 5,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -3284,11 +3284,11 @@ describe("page/tree/delete", () => {
             startOffset: 2,
             endOffset: 4,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 1d: Test 2", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -3330,7 +3330,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: 1,
             previouslyInsertedNodeOffset: 5,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -3389,11 +3389,11 @@ describe("page/tree/delete", () => {
             startOffset: 3,
             endOffset: 4,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 1d: Test 3", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -3435,7 +3435,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: 1,
             previouslyInsertedNodeOffset: 5,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -3494,11 +3494,11 @@ describe("page/tree/delete", () => {
             startOffset: 2,
             endOffset: 3,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 1d: Test 4", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -3540,7 +3540,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -3599,11 +3599,11 @@ describe("page/tree/delete", () => {
             startOffset: 4,
             endOffset: 6,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 1d: Test 5", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -3645,7 +3645,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndef",
@@ -3704,11 +3704,11 @@ describe("page/tree/delete", () => {
             startOffset: 4,
             endOffset: 5,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 1d: Test 6", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndefgh",
@@ -3750,7 +3750,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndefgh",
@@ -3809,11 +3809,11 @@ describe("page/tree/delete", () => {
             startOffset: 6,
             endOffset: 8,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 1d: Test 7", () => {
-          const page: PageContent = {
+          const page: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndefgh",
@@ -3855,7 +3855,7 @@ describe("page/tree/delete", () => {
             previouslyInsertedNodeIndex: null,
             previouslyInsertedNodeOffset: null,
           };
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 content: "abc\ndefgh",
@@ -3914,7 +3914,7 @@ describe("page/tree/delete", () => {
             startOffset: 1,
             endOffset: 3,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
       });
     });
@@ -3923,7 +3923,7 @@ describe("page/tree/delete", () => {
       describe("Scenario 2a: delete from the start of a node to the end of another node", () => {
         test("Scenario 2a: Test 1", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -4104,12 +4104,12 @@ describe("page/tree/delete", () => {
             startOffset: 66,
             endOffset: 94,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 2a: Test 2", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -4290,12 +4290,12 @@ describe("page/tree/delete", () => {
             startOffset: 65,
             endOffset: 94,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 2a: Test 3", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -4476,12 +4476,12 @@ describe("page/tree/delete", () => {
             startOffset: 0,
             endOffset: 94,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 2a: Test 4", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -4662,12 +4662,12 @@ describe("page/tree/delete", () => {
             startOffset: 83,
             endOffset: 88,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 2a: Test 5", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -4848,12 +4848,12 @@ describe("page/tree/delete", () => {
             startOffset: 83,
             endOffset: 127,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 2a: Test 6", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -5034,12 +5034,12 @@ describe("page/tree/delete", () => {
             startOffset: 93,
             endOffset: 127,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 2a: Test 7", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -5220,12 +5220,12 @@ describe("page/tree/delete", () => {
             startOffset: 0,
             endOffset: 80,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 2a: Test 8", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -5406,14 +5406,14 @@ describe("page/tree/delete", () => {
             startOffset: 80,
             endOffset: 85,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
       });
 
       describe("Scenario 2b: delete from the start of a node to a point in another node", () => {
         test("Scenario 2b: Test 1", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -5594,12 +5594,12 @@ describe("page/tree/delete", () => {
             startOffset: 66,
             endOffset: 90,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 2b: Test 2", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -5776,12 +5776,12 @@ describe("page/tree/delete", () => {
             startOffset: 0,
             endOffset: 84,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 2b: Test 3", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -5962,12 +5962,12 @@ describe("page/tree/delete", () => {
             startOffset: 65,
             endOffset: 70,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 2b: Test 4", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -6148,14 +6148,14 @@ describe("page/tree/delete", () => {
             startOffset: 87,
             endOffset: 90,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
       });
 
       describe("Scenario 2c: delete from a point in a node to the end of another node", () => {
         test("Scenario 2c: Test 1", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -6336,12 +6336,12 @@ describe("page/tree/delete", () => {
             startOffset: 31,
             endOffset: 66,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 2c: Test 2", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -6522,12 +6522,12 @@ describe("page/tree/delete", () => {
             startOffset: 81,
             endOffset: 85,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 2c: Test 3", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -6708,12 +6708,12 @@ describe("page/tree/delete", () => {
             startOffset: 84,
             endOffset: 87,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 2c: Test 4", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -6894,12 +6894,12 @@ describe("page/tree/delete", () => {
             startOffset: 120,
             endOffset: 127,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 2c: Test 5", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -7080,12 +7080,12 @@ describe("page/tree/delete", () => {
             startOffset: 90,
             endOffset: 127,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 2c: Test 6", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -7266,14 +7266,14 @@ describe("page/tree/delete", () => {
             startOffset: 60,
             endOffset: 127,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
       });
 
       describe("Scenario 2d: delete from a point in a node to a point in another node", () => {
         test("Scenario 2d: Test 1", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -7454,12 +7454,12 @@ describe("page/tree/delete", () => {
             startOffset: 60,
             endOffset: 70,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 2d: Test 2", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -7640,12 +7640,12 @@ describe("page/tree/delete", () => {
             startOffset: 30,
             endOffset: 70,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 2d: Test 3", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -7826,12 +7826,12 @@ describe("page/tree/delete", () => {
             startOffset: 84,
             endOffset: 89,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 2d: Test 4", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -8012,12 +8012,12 @@ describe("page/tree/delete", () => {
             startOffset: 81,
             endOffset: 86,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
 
         test("Scenario 2d: Test 5", () => {
           const page = getStartPage();
-          const expectedPage: PageContent = {
+          const expectedPage: PageContentMutable = {
             buffers: [
               {
                 isReadOnly: true,
@@ -8198,7 +8198,7 @@ describe("page/tree/delete", () => {
             startOffset: 89,
             endOffset: 100,
           });
-          expect(page).toStrictEqual(expectedPage)
+          expect(page).toStrictEqual(expectedPage);
         });
       });
     });

--- a/src/page/tree/delete.test.ts
+++ b/src/page/tree/delete.test.ts
@@ -1,4 +1,4 @@
-import { Color, NEWLINE, PageContent } from "../model";
+import { Color, NEWLINE, PageContent, PageContentMutable } from "../model";
 import { getStartPage } from "../reducer.test";
 import { deleteContent, deleteNode } from "./delete";
 import { SENTINEL, SENTINEL_INDEX } from "./tree";
@@ -6,7 +6,7 @@ import { SENTINEL, SENTINEL_INDEX } from "./tree";
 describe("page/tree/delete", () => {
   describe("delete node", () => {
     test("Scenario 1: Simple case", () => {
-      const page: PageContent = {
+      const page: PageContentMutable = {
         buffers: [],
         previouslyInsertedNodeIndex: null,
         previouslyInsertedNodeOffset: null,
@@ -94,7 +94,7 @@ describe("page/tree/delete", () => {
           },
         ],
       };
-      const expectedPage: PageContent = {
+      const expectedPage: PageContentMutable = {
         buffers: [],
         previouslyInsertedNodeIndex: null,
         previouslyInsertedNodeOffset: null,
@@ -182,13 +182,13 @@ describe("page/tree/delete", () => {
           },
         ],
       };
-      const receivedPage = deleteNode(page, 1);
-      expect(receivedPage).toStrictEqual(expectedPage);
+      deleteNode(page, 1);
+      expect(page).toStrictEqual(expectedPage);
     });
 
     describe("Sibling s is black and at least one of s's children is red", () => {
       test("Scenario 2: Right right case", () => {
-        const page: PageContent = {
+        const page: PageContentMutable = {
           buffers: [],
           previouslyInsertedNodeIndex: null,
           previouslyInsertedNodeOffset: null,
@@ -293,7 +293,7 @@ describe("page/tree/delete", () => {
             },
           ],
         };
-        const expectedPage: PageContent = {
+        const expectedPage: PageContentMutable = {
           buffers: [],
           previouslyInsertedNodeIndex: null,
           previouslyInsertedNodeOffset: null,
@@ -398,12 +398,12 @@ describe("page/tree/delete", () => {
             },
           ],
         };
-        const receivedPage = deleteNode(page, 1);
-        expect(receivedPage).toStrictEqual(expectedPage);
+        deleteNode(page, 1);
+        expect(page).toStrictEqual(expectedPage);
       });
 
       test("Scenario 3: Right left case", () => {
-        const page: PageContent = {
+        const page: PageContentMutable = {
           buffers: [],
           previouslyInsertedNodeIndex: null,
           previouslyInsertedNodeOffset: null,
@@ -491,7 +491,7 @@ describe("page/tree/delete", () => {
             },
           ],
         };
-        const expectedPage: PageContent = {
+        const expectedPage: PageContentMutable = {
           buffers: [],
           previouslyInsertedNodeIndex: null,
           previouslyInsertedNodeOffset: null,
@@ -577,12 +577,12 @@ describe("page/tree/delete", () => {
             },
           ],
         };
-        const receivedPage = deleteNode(page, 1);
-        expect(receivedPage).toStrictEqual(expectedPage);
+        deleteNode(page, 1);
+        expect(page).toStrictEqual(expectedPage);
       });
 
       test("Scenario 4: Left left case", () => {
-        const page: PageContent = {
+        const page: PageContentMutable = {
           buffers: [],
           previouslyInsertedNodeIndex: null,
           previouslyInsertedNodeOffset: null,
@@ -687,7 +687,7 @@ describe("page/tree/delete", () => {
             },
           ],
         };
-        const expectedPage: PageContent = {
+        const expectedPage: PageContentMutable = {
           buffers: [],
           previouslyInsertedNodeIndex: null,
           previouslyInsertedNodeOffset: null,
@@ -792,12 +792,12 @@ describe("page/tree/delete", () => {
             },
           ],
         };
-        const receivedPage = deleteNode(page, 5);
-        expect(receivedPage).toStrictEqual(expectedPage);
+        deleteNode(page, 5);
+        expect(page).toStrictEqual(expectedPage);
       });
 
       test("Scenario 5: Left right case", () => {
-        const page: PageContent = {
+        const page: PageContentMutable = {
           buffers: [],
           previouslyInsertedNodeIndex: null,
           previouslyInsertedNodeOffset: null,
@@ -883,7 +883,7 @@ describe("page/tree/delete", () => {
             },
           ],
         };
-        const expectedPage: PageContent = {
+        const expectedPage: PageContentMutable = {
           buffers: [],
           previouslyInsertedNodeIndex: null,
           previouslyInsertedNodeOffset: null,
@@ -969,13 +969,13 @@ describe("page/tree/delete", () => {
             },
           ],
         };
-        const receivedPage = deleteNode(page, 4);
-        expect(receivedPage).toStrictEqual(expectedPage);
+        deleteNode(page, 4);
+        expect(page).toStrictEqual(expectedPage);
       });
     });
 
     test("Scenario 6: Sibling s is black, and both its children are black", () => {
-      const page: PageContent = {
+      const page: PageContentMutable = {
         buffers: [],
         previouslyInsertedNodeIndex: null,
         previouslyInsertedNodeOffset: null,
@@ -1042,7 +1042,7 @@ describe("page/tree/delete", () => {
           },
         ],
       };
-      const expectedPage: PageContent = {
+      const expectedPage: PageContentMutable = {
         buffers: [],
         previouslyInsertedNodeIndex: null,
         previouslyInsertedNodeOffset: null,
@@ -1109,13 +1109,13 @@ describe("page/tree/delete", () => {
           },
         ],
       };
-      const receivedPage = deleteNode(page, 1);
-      expect(receivedPage).toStrictEqual(expectedPage);
+      deleteNode(page, 1);
+      expect(page).toStrictEqual(expectedPage);
     });
 
     describe("Sibling s is red", () => {
       test("Scenario 7: sibling s is right child of its parent", () => {
-        const page: PageContent = {
+        const page: PageContentMutable = {
           buffers: [],
           previouslyInsertedNodeIndex: null,
           previouslyInsertedNodeOffset: null,
@@ -1220,7 +1220,7 @@ describe("page/tree/delete", () => {
             },
           ],
         };
-        const expectedPage: PageContent = {
+        const expectedPage: PageContentMutable = {
           buffers: [],
           previouslyInsertedNodeIndex: null,
           previouslyInsertedNodeOffset: null,
@@ -1325,12 +1325,12 @@ describe("page/tree/delete", () => {
             },
           ],
         };
-        const receivedPage = deleteNode(page, 1);
-        expect(receivedPage).toStrictEqual(expectedPage);
+        deleteNode(page, 1);
+        expect(page).toStrictEqual(expectedPage);
       });
 
       test("Scenario 8: sibling s is left child of its parent", () => {
-        const page: PageContent = {
+        const page: PageContentMutable = {
           buffers: [],
           previouslyInsertedNodeIndex: null,
           previouslyInsertedNodeOffset: null,
@@ -1435,7 +1435,7 @@ describe("page/tree/delete", () => {
             },
           ],
         };
-        const expectedPage: PageContent = {
+        const expectedPage: PageContentMutable = {
           buffers: [],
           previouslyInsertedNodeIndex: null,
           previouslyInsertedNodeOffset: null,
@@ -1540,13 +1540,13 @@ describe("page/tree/delete", () => {
             },
           ],
         };
-        const receivedPage = deleteNode(page, 5);
-        expect(receivedPage).toStrictEqual(expectedPage);
+        deleteNode(page, 5);
+        expect(page).toStrictEqual(expectedPage);
       });
     });
 
     test("Scenario 9: delete root", () => {
-      const page: PageContent = {
+      const page: PageContentMutable = {
         buffers: [],
         previouslyInsertedNodeIndex: null,
         previouslyInsertedNodeOffset: null,
@@ -1575,7 +1575,7 @@ describe("page/tree/delete", () => {
           },
         ],
       };
-      const expectedPage: PageContent = {
+      const expectedPage: PageContentMutable = {
         buffers: [],
         previouslyInsertedNodeIndex: null,
         previouslyInsertedNodeOffset: null,
@@ -1604,8 +1604,8 @@ describe("page/tree/delete", () => {
           },
         ],
       };
-      const receivedPage = deleteNode(page, 1);
-      expect(receivedPage).toStrictEqual(expectedPage);
+      deleteNode(page, 1);
+      expect(page).toStrictEqual(expectedPage);
     });
   });
 

--- a/src/page/tree/delete.ts
+++ b/src/page/tree/delete.ts
@@ -471,7 +471,7 @@ function fixDelete(page: PageContentMutable, x: number): void {
           ...page.nodes[page.nodes[x].parent],
           color: Color.Red,
         };
-        page = leftRotate(page, page.nodes[x].parent);
+        leftRotate(page, page.nodes[x].parent);
         w = page.nodes[page.nodes[x].parent].right;
         (page.nodes[w] as NodeMutable) = { ...page.nodes[w] };
       }
@@ -505,7 +505,7 @@ function fixDelete(page: PageContentMutable, x: number): void {
           ...page.nodes[page.nodes[w].right],
           color: Color.Black,
         };
-        page = leftRotate(page, page.nodes[x].parent);
+        leftRotate(page, page.nodes[x].parent);
         x = page.root;
         (page.nodes[x] as NodeMutable) = { ...page.nodes[x] };
       }
@@ -538,7 +538,7 @@ function fixDelete(page: PageContentMutable, x: number): void {
             color: Color.Black,
           };
           (page.nodes[w] as NodeMutable).color = Color.Red;
-          page = leftRotate(page, w);
+          leftRotate(page, w);
           w = page.nodes[page.nodes[x].parent].left;
         }
 

--- a/src/page/tree/delete.ts
+++ b/src/page/tree/delete.ts
@@ -15,7 +15,6 @@ import {
   NodePositionOffset,
   recomputeTreeMetadata,
   resetSentinel,
-  SENTINEL,
   SENTINEL_INDEX,
   treeMinimum,
   updateTreeMetadata,
@@ -431,7 +430,7 @@ export function deleteNode(
     return page;
   }
 
-  page = fixDelete(page, x);
+  fixDelete(page, x);
   resetSentinel(page);
   return page;
 }
@@ -468,7 +467,7 @@ function detach(page: PageContentMutable, node: number): void {
  * @param page The page/piece table.
  * @param x The node to start the fixup from.
  */
-function fixDelete(page: PageContentMutable, x: number): PageContentMutable {
+function fixDelete(page: PageContentMutable, x: number): void {
   let w: number;
 
   while (x !== page.root && page.nodes[x].color === Color.Black) {
@@ -573,8 +572,6 @@ function fixDelete(page: PageContentMutable, x: number): PageContentMutable {
     ...page.nodes[x],
     color: Color.Black,
   };
-
-  return page;
 }
 
 /**

--- a/src/page/tree/delete.ts
+++ b/src/page/tree/delete.ts
@@ -88,8 +88,8 @@ export function deleteContent(
     page = fixInsert(page, page.nodes.length - 1);
   } else if (nodeBeforeContent.length > 0 && nodeAfterContent.length > 0) {
     // delete from a point in a node to the end of another node
-    page = updateNode(page, oldNodeStartPosition.nodeIndex, nodeBeforeContent);
-    page = updateNode(page, oldNodeEndPosition.nodeIndex, nodeAfterContent);
+    updateNode(page, oldNodeStartPosition.nodeIndex, nodeBeforeContent);
+    updateNode(page, oldNodeEndPosition.nodeIndex, nodeAfterContent);
     firstNodeToDelete = nextNode(page, firstNodeToDelete).index;
   } else if (nodeBeforeContent.length > 0) {
     // delete from a point in the node to the end of the node
@@ -104,7 +104,7 @@ export function deleteContent(
     }
   } else if (nodeAfterContent.length > 0) {
     // delete from the start of the node to a point in the node
-    page = updateNode(page, oldNodeEndPosition.nodeIndex, nodeAfterContent);
+    updateNode(page, oldNodeEndPosition.nodeIndex, nodeAfterContent);
   } else if (oldNodeStartPosition === oldNodeEndPosition) {
     // delete the entire node
     deleteNode(page, oldNodeStartPosition.nodeIndex);
@@ -134,7 +134,7 @@ function updateNode(
   page: PageContentMutable,
   index: number,
   newNode: NodeMutable,
-): PageContentMutable {
+): void {
   newNode.leftCharCount = page.nodes[index].leftCharCount;
   newNode.leftLineFeedCount = page.nodes[index].leftLineFeedCount;
   newNode.parent = page.nodes[index].parent;
@@ -143,7 +143,6 @@ function updateNode(
   newNode.color = page.nodes[index].color;
   page.nodes[index] = newNode;
   recomputeTreeMetadata(page, index);
-  return page;
 }
 
 /**

--- a/src/page/tree/delete.ts
+++ b/src/page/tree/delete.ts
@@ -142,7 +142,7 @@ function updateNode(
   newNode.right = page.nodes[index].right;
   newNode.color = page.nodes[index].color;
   page.nodes[index] = newNode;
-  page = recomputeTreeMetadata(page, index);
+  recomputeTreeMetadata(page, index);
   return page;
 }
 
@@ -336,7 +336,7 @@ export function deleteNode(page: PageContentMutable, z: number): void {
 
   if (y === z) {
     (page.nodes[x] as NodeMutable).parent = page.nodes[y].parent;
-    page = recomputeTreeMetadata(page, x);
+    recomputeTreeMetadata(page, x);
   } else {
     if (page.nodes[y].parent === z) {
       (page.nodes[x] as NodeMutable).parent = y;
@@ -345,7 +345,7 @@ export function deleteNode(page: PageContentMutable, z: number): void {
     }
 
     // as we make changes to page.nodes[x]'s hierarchy, update leftCharCount of subtree first
-    page = recomputeTreeMetadata(page, x);
+    recomputeTreeMetadata(page, x);
 
     (page.nodes[y] as NodeMutable).left = page.nodes[z].left;
     (page.nodes[y] as NodeMutable).right = page.nodes[z].right;
@@ -385,7 +385,7 @@ export function deleteNode(page: PageContentMutable, z: number): void {
     (page.nodes[y] as NodeMutable).leftCharCount = page.nodes[z].leftCharCount;
     (page.nodes[y] as NodeMutable).leftLineFeedCount =
       page.nodes[z].leftLineFeedCount;
-    page = recomputeTreeMetadata(page, y);
+    recomputeTreeMetadata(page, y);
   }
 
   detach(page, z);
@@ -415,7 +415,7 @@ export function deleteNode(page: PageContentMutable, z: number): void {
     }
   }
 
-  page = recomputeTreeMetadata(page, page.nodes[x].parent);
+  recomputeTreeMetadata(page, page.nodes[x].parent);
 
   if (yWasRed) {
     resetSentinel(page);

--- a/src/page/tree/delete.ts
+++ b/src/page/tree/delete.ts
@@ -490,7 +490,7 @@ function fixDelete(page: PageContentMutable, x: number): void {
             color: Color.Black,
           };
           (page.nodes[w] as NodeMutable).color = Color.Red;
-          page = rightRotate(page, w);
+          rightRotate(page, w);
           w = page.nodes[page.nodes[x].parent].right;
           (page.nodes[w] as NodeMutable) = { ...page.nodes[w] };
         }
@@ -519,7 +519,7 @@ function fixDelete(page: PageContentMutable, x: number): void {
           ...page.nodes[page.nodes[x].parent],
           color: Color.Red,
         };
-        page = rightRotate(page, page.nodes[x].parent);
+        rightRotate(page, page.nodes[x].parent);
         w = page.nodes[page.nodes[x].parent].left;
         (page.nodes[w] as NodeMutable) = { ...page.nodes[w] };
       }
@@ -552,7 +552,7 @@ function fixDelete(page: PageContentMutable, x: number): void {
           ...page.nodes[page.nodes[w].left],
           color: Color.Black,
         };
-        page = rightRotate(page, page.nodes[x].parent);
+        rightRotate(page, page.nodes[x].parent);
         x = page.root;
         (page.nodes[x] as NodeMutable) = { ...page.nodes[x] };
       }

--- a/src/page/tree/delete.ts
+++ b/src/page/tree/delete.ts
@@ -117,11 +117,7 @@ export function deleteContent(
   page.previouslyInsertedNodeOffset = null;
 
   if (oldNodeStartPosition.nodeIndex !== oldNodeEndPosition.nodeIndex) {
-    page = deleteBetweenNodes(
-      page,
-      firstNodeToDelete,
-      nodeAfterLastNodeToDelete,
-    );
+    deleteBetweenNodes(page, firstNodeToDelete, nodeAfterLastNodeToDelete);
   }
   resetSentinel(page);
   return page;
@@ -268,7 +264,7 @@ function deleteBetweenNodes(
   page: PageContentMutable,
   startIndex: number,
   endIndex: number,
-): PageContentMutable {
+): void {
   let currentIndex = startIndex;
   let nextIndex = currentIndex;
   while (nextIndex !== endIndex) {
@@ -276,7 +272,6 @@ function deleteBetweenNodes(
     nextIndex = nextNode(page, currentIndex).index;
     deleteNode(page, currentIndex);
   }
-  return page;
 }
 
 /**

--- a/src/page/tree/delete.ts
+++ b/src/page/tree/delete.ts
@@ -84,7 +84,7 @@ export function deleteContent(
     (page.nodes[
       oldNodeStartPosition.nodeIndex
     ] as NodeMutable) = nodeBeforeContent;
-    page = insertNode(page, nodeAfterContent, deleteRange.startOffset);
+    insertNode(page, nodeAfterContent, deleteRange.startOffset);
     page = fixInsert(page, page.nodes.length - 1);
   } else if (nodeBeforeContent.length > 0 && nodeAfterContent.length > 0) {
     // delete from a point in a node to the end of another node

--- a/src/page/tree/delete.ts
+++ b/src/page/tree/delete.ts
@@ -85,7 +85,7 @@ export function deleteContent(
       oldNodeStartPosition.nodeIndex
     ] as NodeMutable) = nodeBeforeContent;
     insertNode(page, nodeAfterContent, deleteRange.startOffset);
-    page = fixInsert(page, page.nodes.length - 1);
+    fixInsert(page, page.nodes.length - 1);
   } else if (nodeBeforeContent.length > 0 && nodeAfterContent.length > 0) {
     // delete from a point in a node to the end of another node
     updateNode(page, oldNodeStartPosition.nodeIndex, nodeBeforeContent);

--- a/src/page/tree/delete.ts
+++ b/src/page/tree/delete.ts
@@ -36,7 +36,7 @@ export interface ContentDelete {
 export function deleteContent(
   page: PageContentMutable,
   deleteRange: ContentDelete,
-): PageContentMutable {
+): void {
   const oldNodeStartPosition = findNodeAtOffset(
     deleteRange.startOffset,
     page.nodes,
@@ -120,7 +120,6 @@ export function deleteContent(
     deleteBetweenNodes(page, firstNodeToDelete, nodeAfterLastNodeToDelete);
   }
   resetSentinel(page);
-  return page;
 }
 
 /**

--- a/src/page/tree/delete.ts
+++ b/src/page/tree/delete.ts
@@ -98,7 +98,7 @@ export function deleteContent(
     ] as NodeMutable) = nodeBeforeContent;
     if (oldNodeStartPosition !== oldNodeEndPosition) {
       // deleting from a point in a node to the end of the content
-      page = deleteNode(page, oldNodeEndPosition.nodeIndex);
+      deleteNode(page, oldNodeEndPosition.nodeIndex);
       nodeAfterLastNodeToDelete = SENTINEL_INDEX;
       firstNodeToDelete = nextNode(page, firstNodeToDelete).index;
     }
@@ -107,7 +107,7 @@ export function deleteContent(
     page = updateNode(page, oldNodeEndPosition.nodeIndex, nodeAfterContent);
   } else if (oldNodeStartPosition === oldNodeEndPosition) {
     // delete the entire node
-    page = deleteNode(page, oldNodeStartPosition.nodeIndex);
+    deleteNode(page, oldNodeStartPosition.nodeIndex);
   } else {
     // deleting up to and including the last node
     nodeAfterLastNodeToDelete = nextNode(page, nodeAfterLastNodeToDelete).index;
@@ -274,7 +274,7 @@ function deleteBetweenNodes(
   while (nextIndex !== endIndex) {
     currentIndex = nextIndex;
     nextIndex = nextNode(page, currentIndex).index;
-    page = deleteNode(page, currentIndex);
+    deleteNode(page, currentIndex);
   }
   return page;
 }
@@ -285,10 +285,7 @@ function deleteBetweenNodes(
  * @param page The page/piece table.
  * @param z The index of the node to delete.
  */
-export function deleteNode(
-  page: PageContentMutable,
-  z: number,
-): PageContentMutable {
+export function deleteNode(page: PageContentMutable, z: number): void {
   page.nodes[z] = { ...page.nodes[z] };
   let xTemp: number;
   let yTemp: number;
@@ -325,7 +322,7 @@ export function deleteNode(
       parent: SENTINEL_INDEX,
     };
     resetSentinel(page);
-    return page;
+    return;
   }
 
   const yWasRed = page.nodes[y].color === Color.Red;
@@ -427,12 +424,12 @@ export function deleteNode(
 
   if (yWasRed) {
     resetSentinel(page);
-    return page;
+    return;
   }
 
   fixDelete(page, x);
   resetSentinel(page);
-  return page;
+  return;
 }
 
 /**

--- a/src/page/tree/insert.test.ts
+++ b/src/page/tree/insert.test.ts
@@ -1482,8 +1482,8 @@ describe("page/tree/insert", () => {
             },
           ],
         };
-        const acquiredPage = fixInsert(page as PageContentMutable, 4);
-        expect(acquiredPage).toStrictEqual(expectedPage);
+        fixInsert(page as PageContentMutable, 4);
+        expect(page).toStrictEqual(expectedPage);
       });
 
       test("Scenario 2: Left right case", () => {
@@ -1707,8 +1707,8 @@ describe("page/tree/insert", () => {
             },
           ],
         };
-        const acquiredPage = fixInsert(page as PageContentMutable, 5);
-        expect(acquiredPage).toStrictEqual(expectedPage);
+        fixInsert(page as PageContentMutable, 5);
+        expect(page).toStrictEqual(expectedPage);
       });
 
       test("Scenario 3: Right right case", () => {
@@ -1932,8 +1932,8 @@ describe("page/tree/insert", () => {
             },
           ],
         };
-        const acquiredPage = fixInsert(page as PageContentMutable, 5);
-        expect(acquiredPage).toStrictEqual(expectedPage);
+        fixInsert(page as PageContentMutable, 5);
+        expect(page).toStrictEqual(expectedPage);
       });
 
       test("Scenario 4: Right left case", () => {
@@ -2157,8 +2157,8 @@ describe("page/tree/insert", () => {
             },
           ],
         };
-        const acquiredPage = fixInsert(page as PageContentMutable, 4);
-        expect(acquiredPage).toStrictEqual(expectedPage);
+        fixInsert(page as PageContentMutable, 4);
+        expect(page).toStrictEqual(expectedPage);
       });
     });
 
@@ -2344,8 +2344,8 @@ describe("page/tree/insert", () => {
           previouslyInsertedNodeOffset: null,
           newlineFormat: NEWLINE.LF,
         };
-        const receivedPage = fixInsert(page as PageContentMutable, 4);
-        expect(receivedPage).toStrictEqual(expectedPage);
+        fixInsert(page as PageContentMutable, 4);
+        expect(page).toStrictEqual(expectedPage);
       });
 
       test("Left red uncle", () => {
@@ -2529,8 +2529,8 @@ describe("page/tree/insert", () => {
           previouslyInsertedNodeOffset: null,
           newlineFormat: NEWLINE.LF,
         };
-        const receivedPage = fixInsert(page as PageContentMutable, 4);
-        expect(receivedPage).toStrictEqual(expectedPage);
+        fixInsert(page as PageContentMutable, 4);
+        expect(page).toStrictEqual(expectedPage);
       });
     });
 
@@ -2573,8 +2573,8 @@ describe("page/tree/insert", () => {
       const expectedPage = getPage();
       (expectedPage.nodes[1] as NodeMutable).color = Color.Black;
       const page = getPage();
-      const receivedPage = fixInsert(page, 1);
-      expect(receivedPage).toStrictEqual(expectedPage);
+      fixInsert(page, 1);
+      expect(page).toStrictEqual(expectedPage);
     });
   });
 });

--- a/src/page/tree/insert.test.ts
+++ b/src/page/tree/insert.test.ts
@@ -1,4 +1,11 @@
-import { Color, NEWLINE, PageContent, PageContentMutable } from "../model";
+import {
+  BufferMutable,
+  Color,
+  NEWLINE,
+  NodeMutable,
+  PageContent,
+  PageContentMutable,
+} from "../model";
 import { ContentInsert, fixInsert, insertContent } from "./insert";
 import { MAX_BUFFER_LENGTH, SENTINEL, SENTINEL_INDEX } from "./tree";
 
@@ -41,9 +48,9 @@ describe("page/tree/insert", () => {
         previouslyInsertedNodeOffset: 0,
       });
       const expectedPage = getPage();
-      expectedPage.buffers[0].content += "b";
-      expectedPage.nodes[1] = {
-        ...expectedPage.nodes[1],
+      (expectedPage.buffers[0] as BufferMutable).content += "b";
+      (expectedPage.nodes[1] as NodeMutable) = {
+        ...(expectedPage.nodes[1] as NodeMutable),
         end: {
           line: 0,
           column: 2,
@@ -102,7 +109,7 @@ describe("page/tree/insert", () => {
         lineStarts: [0],
         content: "ef",
       });
-      expectedPage.nodes[1].right = 2;
+      ((expectedPage.nodes[1] as NodeMutable) as NodeMutable).right = 2;
       expectedPage.nodes.push({
         bufferIndex: 1,
         start: {
@@ -130,8 +137,8 @@ describe("page/tree/insert", () => {
         offset: 5,
       };
       const maxBufferLength = 5;
-      const receivedPage = insertContent(page, content, maxBufferLength);
-      expect(receivedPage).toStrictEqual(expectedPage);
+      insertContent(page, content, maxBufferLength);
+      expect(page).toStrictEqual(expectedPage);
     });
 
     test("Scenario 3: insert at the end of a node (test 1)", () => {
@@ -203,10 +210,11 @@ describe("page/tree/insert", () => {
       });
       const page = getPage();
       const expectedPage = getPage();
-      expectedPage.buffers[1].content += "ij\nk";
-      expectedPage.buffers[1].lineStarts.push(7);
-      expectedPage.nodes[1].leftCharCount = 6;
-      expectedPage.nodes[1].leftLineFeedCount = 1;
+      ((expectedPage.buffers[1] as BufferMutable) as BufferMutable).content +=
+        "ij\nk";
+      (expectedPage.buffers[1] as BufferMutable).lineStarts.push(7);
+      (expectedPage.nodes[1] as NodeMutable).leftCharCount = 6;
+      (expectedPage.nodes[1] as NodeMutable).leftLineFeedCount = 1;
       expectedPage.nodes.push({
         bufferIndex: 1,
         start: { line: 0, column: 4 },
@@ -220,9 +228,9 @@ describe("page/tree/insert", () => {
         left: SENTINEL_INDEX,
         right: SENTINEL_INDEX,
       });
-      expectedPage.nodes[2].right = 4;
-      expectedPage.nodes[2].color = Color.Black;
-      expectedPage.nodes[3].color = Color.Black;
+      (expectedPage.nodes[2] as NodeMutable).right = 4;
+      (expectedPage.nodes[2] as NodeMutable).color = Color.Black;
+      (expectedPage.nodes[3] as NodeMutable).color = Color.Black;
       expectedPage.previouslyInsertedNodeIndex = 4;
       expectedPage.previouslyInsertedNodeOffset = 2;
       const content: ContentInsert = {
@@ -230,8 +238,8 @@ describe("page/tree/insert", () => {
         offset: 2,
       };
       const maxBufferLength = 8;
-      const receivedPage = insertContent(page, content, maxBufferLength);
-      expect(receivedPage).toStrictEqual(expectedPage);
+      insertContent(page, content, maxBufferLength);
+      expect(page).toStrictEqual(expectedPage);
     });
 
     test("Scenario 3: insert at the end of a node (test 2)", () => {
@@ -303,8 +311,8 @@ describe("page/tree/insert", () => {
       });
       const page = getPage();
       const expectedPage = getPage();
-      expectedPage.buffers[1].content += "ij\nk";
-      expectedPage.buffers[1].lineStarts.push(7);
+      (expectedPage.buffers[1] as BufferMutable).content += "ij\nk";
+      (expectedPage.buffers[1] as BufferMutable).lineStarts.push(7);
       expectedPage.nodes.push({
         bufferIndex: 1,
         start: { line: 0, column: 4 },
@@ -318,9 +326,9 @@ describe("page/tree/insert", () => {
         left: SENTINEL_INDEX,
         right: SENTINEL_INDEX,
       });
-      expectedPage.nodes[2].right = 4;
-      expectedPage.nodes[2].color = Color.Black;
-      expectedPage.nodes[3].color = Color.Black;
+      (expectedPage.nodes[2] as NodeMutable).right = 4;
+      (expectedPage.nodes[2] as NodeMutable).color = Color.Black;
+      (expectedPage.nodes[3] as NodeMutable).color = Color.Black;
       expectedPage.previouslyInsertedNodeIndex = 4;
       expectedPage.previouslyInsertedNodeOffset = 9;
       const content: ContentInsert = {
@@ -419,11 +427,11 @@ describe("page/tree/insert", () => {
         left: SENTINEL_INDEX,
         right: SENTINEL_INDEX,
       });
-      expectedPage.nodes[1].leftCharCount = 7;
-      expectedPage.nodes[1].leftLineFeedCount = 1;
-      expectedPage.nodes[2].right = 4;
-      expectedPage.nodes[2].color = Color.Black;
-      expectedPage.nodes[3].color = Color.Black;
+      (expectedPage.nodes[1] as NodeMutable).leftCharCount = 7;
+      (expectedPage.nodes[1] as NodeMutable).leftLineFeedCount = 1;
+      (expectedPage.nodes[2] as NodeMutable).right = 4;
+      (expectedPage.nodes[2] as NodeMutable).color = Color.Black;
+      (expectedPage.nodes[3] as NodeMutable).color = Color.Black;
       expectedPage.previouslyInsertedNodeIndex = 4;
       expectedPage.previouslyInsertedNodeOffset = 2;
       const content: ContentInsert = {
@@ -490,7 +498,7 @@ describe("page/tree/insert", () => {
         left: SENTINEL_INDEX,
         right: SENTINEL_INDEX,
       });
-      expectedPage.nodes[1].right = 2;
+      (expectedPage.nodes[1] as NodeMutable).right = 2;
       const page = getPage();
       const content: ContentInsert = {
         content: "ef",
@@ -628,8 +636,8 @@ describe("page/tree/insert", () => {
         offset: 0,
       };
       const maxBufferLength = 8;
-      const receivedPage = insertContent(page, content, maxBufferLength);
-      expect(receivedPage).toStrictEqual(expectedPage);
+      insertContent(page as PageContentMutable, content, maxBufferLength);
+      expect(page).toStrictEqual(expectedPage);
     });
 
     test("Scenario 6: insert at the start of the content (test 1)", () => {
@@ -752,8 +760,8 @@ describe("page/tree/insert", () => {
         offset: 0,
       };
       const maxBufferLength = 8;
-      const receivedPage = insertContent(page, content, maxBufferLength);
-      expect(receivedPage).toStrictEqual(expectedPage);
+      insertContent(page as PageContentMutable, content, maxBufferLength);
+      expect(page).toStrictEqual(expectedPage);
     });
 
     test("Scenario 6: insert at the start of the content (test 2)", () => {
@@ -850,8 +858,8 @@ describe("page/tree/insert", () => {
         offset: 0,
       };
       const maxBufferLength = 8;
-      const receivedPage = insertContent(page, content, maxBufferLength);
-      expect(receivedPage).toStrictEqual(expectedPage);
+      insertContent(page as PageContentMutable, content, maxBufferLength);
+      expect(page).toStrictEqual(expectedPage);
     });
 
     test("Scenario 7: insert inside a node's content", () => {
@@ -996,8 +1004,8 @@ describe("page/tree/insert", () => {
         offset: 5,
       };
       const maxBufferLength = 16;
-      const receivedPage = insertContent(page, content, maxBufferLength);
-      expect(receivedPage).toStrictEqual(expectedPage);
+      insertContent(page as PageContentMutable, content, maxBufferLength);
+      expect(page).toStrictEqual(expectedPage);
     });
 
     test("Scenario 8: insert inside a node's content (test 1)", () => {
@@ -1147,8 +1155,8 @@ describe("page/tree/insert", () => {
         content: "ij\nkl\nmn",
       };
       const maxBufferLength = 16;
-      const receivedPage = insertContent(page, content, maxBufferLength);
-      expect(receivedPage).toStrictEqual(expectedPage);
+      insertContent(page as PageContentMutable, content, maxBufferLength);
+      expect(page).toStrictEqual(expectedPage);
     });
 
     test("Scenario 8: insert inside a node's content (test 2", () => {
@@ -1246,8 +1254,8 @@ describe("page/tree/insert", () => {
         content: "ef",
       };
       const maxBufferLength = 8;
-      const receivedPage = insertContent(page, content, maxBufferLength);
-      expect(receivedPage).toStrictEqual(expectedPage);
+      insertContent(page as PageContentMutable, content, maxBufferLength);
+      expect(page).toStrictEqual(expectedPage);
     });
   });
 
@@ -1474,7 +1482,7 @@ describe("page/tree/insert", () => {
             },
           ],
         };
-        const acquiredPage = fixInsert(page, 4);
+        const acquiredPage = fixInsert(page as PageContentMutable, 4);
         expect(acquiredPage).toStrictEqual(expectedPage);
       });
 
@@ -1699,7 +1707,7 @@ describe("page/tree/insert", () => {
             },
           ],
         };
-        const acquiredPage = fixInsert(page, 5);
+        const acquiredPage = fixInsert(page as PageContentMutable, 5);
         expect(acquiredPage).toStrictEqual(expectedPage);
       });
 
@@ -1924,7 +1932,7 @@ describe("page/tree/insert", () => {
             },
           ],
         };
-        const acquiredPage = fixInsert(page, 5);
+        const acquiredPage = fixInsert(page as PageContentMutable, 5);
         expect(acquiredPage).toStrictEqual(expectedPage);
       });
 
@@ -2149,7 +2157,7 @@ describe("page/tree/insert", () => {
             },
           ],
         };
-        const acquiredPage = fixInsert(page, 4);
+        const acquiredPage = fixInsert(page as PageContentMutable, 4);
         expect(acquiredPage).toStrictEqual(expectedPage);
       });
     });
@@ -2336,7 +2344,7 @@ describe("page/tree/insert", () => {
           previouslyInsertedNodeOffset: null,
           newlineFormat: NEWLINE.LF,
         };
-        const receivedPage = fixInsert(page, 4);
+        const receivedPage = fixInsert(page as PageContentMutable, 4);
         expect(receivedPage).toStrictEqual(expectedPage);
       });
 
@@ -2521,7 +2529,7 @@ describe("page/tree/insert", () => {
           previouslyInsertedNodeOffset: null,
           newlineFormat: NEWLINE.LF,
         };
-        const receivedPage = fixInsert(page, 4);
+        const receivedPage = fixInsert(page as PageContentMutable, 4);
         expect(receivedPage).toStrictEqual(expectedPage);
       });
     });
@@ -2563,7 +2571,7 @@ describe("page/tree/insert", () => {
         previouslyInsertedNodeOffset: 0,
       });
       const expectedPage = getPage();
-      expectedPage.nodes[1].color = Color.Black;
+      (expectedPage.nodes[1] as NodeMutable).color = Color.Black;
       const page = getPage();
       const receivedPage = fixInsert(page, 1);
       expect(receivedPage).toStrictEqual(expectedPage);

--- a/src/page/tree/insert.test.ts
+++ b/src/page/tree/insert.test.ts
@@ -64,7 +64,7 @@ describe("page/tree/insert", () => {
         offset: 1,
       };
       const receivedPage = insertContent(page, content, MAX_BUFFER_LENGTH);
-      expect(receivedPage).toStrictEqual(expectedPage);
+      expect(page).toStrictEqual(expectedPage);
     });
 
     test("Scenario 2: insert at the end of the previously inserted node", () => {
@@ -336,8 +336,8 @@ describe("page/tree/insert", () => {
         offset: 9,
       };
       const maxBufferLength = 8;
-      const receivedPage = insertContent(page, content, maxBufferLength);
-      expect(receivedPage).toStrictEqual(expectedPage);
+      insertContent(page, content, maxBufferLength);
+      expect(page).toStrictEqual(expectedPage);
     });
 
     test("Scenario 4: insert at the end of a node (test 1)", () => {
@@ -439,8 +439,8 @@ describe("page/tree/insert", () => {
         offset: 2,
       };
       const maxBufferLength = 8;
-      const receivedPage = insertContent(page, content, maxBufferLength);
-      expect(receivedPage).toStrictEqual(expectedPage);
+      insertContent(page, content, maxBufferLength);
+      expect(page).toStrictEqual(expectedPage);
     });
 
     test("Scenario 4: insert at the end of a node (test 2)", () => {
@@ -507,8 +507,8 @@ describe("page/tree/insert", () => {
       expectedPage.previouslyInsertedNodeIndex = 2;
       expectedPage.previouslyInsertedNodeOffset = 5;
       const maxBufferLength = 8;
-      const receivedPage = insertContent(page, content, maxBufferLength);
-      expect(receivedPage).toStrictEqual(expectedPage);
+      insertContent(page, content, maxBufferLength);
+      expect(page).toStrictEqual(expectedPage);
     });
 
     test("Scenario 5: insert at the start of the content", () => {

--- a/src/page/tree/insert.ts
+++ b/src/page/tree/insert.ts
@@ -60,7 +60,7 @@ export function insertContent(
   }
 
   if (page) {
-    return fixInsert(page, page.nodes.length - 1);
+    fixInsert(page, page.nodes.length - 1);
   }
   return page;
 }
@@ -70,16 +70,13 @@ export function insertContent(
  * @param page The page/piece table.
  * @param x The index of the node in the `node` array, which is the basis for fixing the tree.
  */
-export function fixInsert(
-  page: PageContentMutable,
-  x: number,
-): PageContentMutable {
+export function fixInsert(page: PageContentMutable, x: number): void {
   recomputeTreeMetadata(page, x);
   page.nodes[x] = { ...page.nodes[x] };
 
   if (x === page.root) {
     (page.nodes[x] as NodeMutable).color = Color.Black;
-    return page;
+    return;
   }
 
   while (
@@ -164,8 +161,6 @@ export function fixInsert(
     ...page.nodes[page.root],
     color: Color.Black,
   };
-
-  return page;
 }
 
 /**
@@ -269,7 +264,7 @@ function insertInsideNode(
   };
 
   insertNode(page, secondPartNode, content.offset);
-  page = fixInsert(page, page.nodes.length - 1);
+  fixInsert(page, page.nodes.length - 1);
   insertAtNodeExtremity(content, page, maxBufferLength);
   page.previouslyInsertedNodeIndex = page.nodes.length - 1;
   page.previouslyInsertedNodeOffset = content.offset;

--- a/src/page/tree/insert.ts
+++ b/src/page/tree/insert.ts
@@ -27,7 +27,7 @@ export function insertContent(
   page: PageContentMutable,
   content: ContentInsert,
   maxBufferLength: number,
-): PageContentMutable {
+): void {
   let previouslyInsertedNode: Node | undefined;
 
   if (
@@ -62,7 +62,6 @@ export function insertContent(
   if (page) {
     fixInsert(page, page.nodes.length - 1);
   }
-  return page;
 }
 
 /**

--- a/src/page/tree/insert.ts
+++ b/src/page/tree/insert.ts
@@ -271,7 +271,7 @@ function insertInsideNode(
     right: SENTINEL_INDEX,
   };
 
-  page = insertNode(page, secondPartNode, content.offset);
+  insertNode(page, secondPartNode, content.offset);
   page = fixInsert(page, page.nodes.length - 1);
   page = insertAtNodeExtremity(content, page, maxBufferLength);
   page.previouslyInsertedNodeIndex = page.nodes.length - 1;
@@ -354,7 +354,7 @@ function createNodeAppendToBuffer(
   page.buffers[page.buffers.length - 1] = updatedBuffer;
   page.previouslyInsertedNodeIndex = page.nodes.length;
   page.previouslyInsertedNodeOffset = content.offset;
-  page = insertNode(page, newNode, content.offset);
+  insertNode(page, newNode, content.offset);
   return page;
 }
 
@@ -393,7 +393,7 @@ function createNodeCreateBuffer(
   page.previouslyInsertedNodeIndex = page.nodes.length;
   page.previouslyInsertedNodeOffset = content.offset;
   page.buffers.push(newBuffer);
-  page = insertNode(page, newNode, content.offset);
+  insertNode(page, newNode, content.offset);
   return page;
 }
 
@@ -407,7 +407,7 @@ export function insertNode(
   page: PageContentMutable,
   newNode: NodeMutable,
   offset: number,
-): PageContentMutable {
+): void {
   page.nodes.push(newNode);
   let prevIndex = SENTINEL_INDEX;
 
@@ -429,7 +429,7 @@ export function insertNode(
           left: nodeIndex,
         };
         newNode.parent = prevIndex; // can mutate the node since it's new
-        return page;
+        return;
       }
       currentNode = page.nodes[currentIndex];
     } else if (
@@ -446,7 +446,7 @@ export function insertNode(
           right: nodeIndex,
         };
         newNode.parent = prevIndex; // can mutate the node since it's new
-        return page;
+        return;
       }
       currentNode = page.nodes[currentIndex];
     } else {

--- a/src/page/tree/insert.ts
+++ b/src/page/tree/insert.ts
@@ -76,7 +76,7 @@ export function fixInsert(
   page: PageContentMutable,
   x: number,
 ): PageContentMutable {
-  page = recomputeTreeMetadata(page, x);
+  recomputeTreeMetadata(page, x);
   page.nodes[x] = { ...page.nodes[x] };
 
   if (x === page.root) {

--- a/src/page/tree/insert.ts
+++ b/src/page/tree/insert.ts
@@ -49,16 +49,14 @@ export function insertContent(
       page.nodes,
       page.root,
     );
-    page =
+    if (
       nodePosition.nodeStartOffset < content.offset &&
       content.offset < nodePosition.nodeStartOffset + nodePosition.node.length
-        ? (page = insertInsideNode(
-            content,
-            page,
-            maxBufferLength,
-            nodePosition,
-          ))
-        : (page = insertAtNodeExtremity(content, page, maxBufferLength));
+    ) {
+      page = insertInsideNode(content, page, maxBufferLength, nodePosition);
+    } else {
+      insertAtNodeExtremity(content, page, maxBufferLength);
+    }
   }
 
   if (page) {
@@ -273,7 +271,7 @@ function insertInsideNode(
 
   insertNode(page, secondPartNode, content.offset);
   page = fixInsert(page, page.nodes.length - 1);
-  page = insertAtNodeExtremity(content, page, maxBufferLength);
+  insertAtNodeExtremity(content, page, maxBufferLength);
   page.previouslyInsertedNodeIndex = page.nodes.length - 1;
   page.previouslyInsertedNodeOffset = content.offset;
   return page;
@@ -290,7 +288,7 @@ function insertAtNodeExtremity(
   content: ContentInsert,
   page: PageContentMutable,
   maxBufferLength: number,
-): PageContentMutable {
+): void {
   // check buffer size
   if (
     content.content.length +
@@ -301,12 +299,12 @@ function insertAtNodeExtremity(
     // scenario 3 and 5: it can fit inside the previous buffer
     // creates a new node
     // appends to the previous buffer
-    return createNodeAppendToBuffer(content, page);
+    createNodeAppendToBuffer(content, page);
   } else {
     // scenario 4 and 6: it cannot fit inside the previous buffer
     // creates a new node
     // creates a new buffer
-    return createNodeCreateBuffer(content, page);
+    createNodeCreateBuffer(content, page);
   }
 }
 
@@ -318,7 +316,7 @@ function insertAtNodeExtremity(
 function createNodeAppendToBuffer(
   content: ContentInsert,
   page: PageContentMutable,
-): PageContentMutable {
+): void {
   const oldBuffer = page.buffers[page.buffers.length - 1];
   const newContent = oldBuffer.content + content.content;
   const updatedBuffer: Buffer = {
@@ -355,7 +353,6 @@ function createNodeAppendToBuffer(
   page.previouslyInsertedNodeIndex = page.nodes.length;
   page.previouslyInsertedNodeOffset = content.offset;
   insertNode(page, newNode, content.offset);
-  return page;
 }
 
 /**

--- a/src/page/tree/insert.ts
+++ b/src/page/tree/insert.ts
@@ -107,7 +107,7 @@ export function fixInsert(page: PageContentMutable, x: number): void {
         if (x === page.nodes[page.nodes[x].parent].right) {
           x = page.nodes[x].parent;
           page.nodes[x] = { ...page.nodes[x] };
-          page = leftRotate(page, x);
+          leftRotate(page, x);
         }
         page.nodes[page.nodes[x].parent] = {
           ...page.nodes[page.nodes[x].parent],
@@ -152,7 +152,7 @@ export function fixInsert(page: PageContentMutable, x: number): void {
           ...page.nodes[page.nodes[page.nodes[x].parent].parent],
           color: Color.Red,
         };
-        page = leftRotate(page, page.nodes[page.nodes[x].parent].parent);
+        leftRotate(page, page.nodes[page.nodes[x].parent].parent);
       }
     }
   }

--- a/src/page/tree/insert.ts
+++ b/src/page/tree/insert.ts
@@ -53,7 +53,7 @@ export function insertContent(
       nodePosition.nodeStartOffset < content.offset &&
       content.offset < nodePosition.nodeStartOffset + nodePosition.node.length
     ) {
-      page = insertInsideNode(content, page, maxBufferLength, nodePosition);
+      insertInsideNode(content, page, maxBufferLength, nodePosition);
     } else {
       insertAtNodeExtremity(content, page, maxBufferLength);
     }
@@ -230,7 +230,7 @@ function insertInsideNode(
   page: PageContentMutable,
   maxBufferLength: number,
   nodePosition: NodePositionOffset,
-): PageContentMutable {
+): void {
   const oldNode = nodePosition.node;
   const nodeContent = getNodeContent(nodePosition.nodeIndex, page);
   const firstPartContent = nodeContent.slice(0, nodePosition.remainder);
@@ -273,7 +273,6 @@ function insertInsideNode(
   insertAtNodeExtremity(content, page, maxBufferLength);
   page.previouslyInsertedNodeIndex = page.nodes.length - 1;
   page.previouslyInsertedNodeOffset = content.offset;
-  return page;
 }
 
 /**

--- a/src/page/tree/insert.ts
+++ b/src/page/tree/insert.ts
@@ -42,7 +42,7 @@ export function insertContent(
     content.offset ===
       page.previouslyInsertedNodeOffset! + previouslyInsertedNode.length
   ) {
-    page = insertAtEndPreviouslyInsertedNode(content, page, maxBufferLength);
+    insertAtEndPreviouslyInsertedNode(content, page, maxBufferLength);
   } else {
     const nodePosition = findNodeAtOffset(
       content.offset,
@@ -178,7 +178,7 @@ function insertAtEndPreviouslyInsertedNode(
   content: ContentInsert,
   page: PageContentMutable,
   maxBufferLength: number,
-): PageContentMutable {
+): void {
   // check buffer size
   if (
     content.content.length +
@@ -210,12 +210,11 @@ function insertAtEndPreviouslyInsertedNode(
 
     page.buffers[page.buffers.length - 1] = buffer;
     page.nodes[page.nodes.length - 1] = node;
-    return page;
   } else {
     // scenario 2: cannot fit inside the previous buffer
     // creates a new node
     // creates a new buffer
-    return createNodeCreateBuffer(content, page);
+    createNodeCreateBuffer(content, page);
   }
 }
 
@@ -363,7 +362,7 @@ function createNodeAppendToBuffer(
 function createNodeCreateBuffer(
   content: ContentInsert,
   page: PageContentMutable,
-): PageContentMutable {
+): void {
   const newBuffer: Buffer = {
     isReadOnly: false,
     lineStarts: getLineStarts(content.content, page.newlineFormat),
@@ -391,7 +390,6 @@ function createNodeCreateBuffer(
   page.previouslyInsertedNodeOffset = content.offset;
   page.buffers.push(newBuffer);
   insertNode(page, newNode, content.offset);
-  return page;
 }
 
 /**

--- a/src/page/tree/insert.ts
+++ b/src/page/tree/insert.ts
@@ -117,7 +117,7 @@ export function fixInsert(page: PageContentMutable, x: number): void {
           ...page.nodes[page.nodes[page.nodes[x].parent].parent],
           color: Color.Red,
         };
-        page = rightRotate(page, page.nodes[page.nodes[x].parent].parent);
+        rightRotate(page, page.nodes[page.nodes[x].parent].parent);
       }
     } else {
       const y = page.nodes[page.nodes[page.nodes[x].parent].parent].left;
@@ -142,7 +142,7 @@ export function fixInsert(page: PageContentMutable, x: number): void {
         ) {
           x = page.nodes[x].parent;
           page.nodes[x] = { ...page.nodes[x] };
-          page = rightRotate(page, x);
+          rightRotate(page, x);
         }
         page.nodes[page.nodes[x].parent] = {
           ...page.nodes[page.nodes[x].parent],

--- a/src/page/tree/rotate.test.ts
+++ b/src/page/tree/rotate.test.ts
@@ -585,81 +585,51 @@ describe("page/tree/rotate", () => {
     previouslyInsertedNodeOffset: 0,
   });
 
-  /**
-   * Returns the number of different references between the nodes, after a rotation.
-   * A rotate function should update no more than four references.
-   * @param oldTable The table passed into the rotate function
-   * @param newTable The table passed out of the rotate function
-   */
-  const getDiffCount = (
-    oldTable: PageContentMutable,
-    newTable: PageContentMutable,
-  ): number => {
-    const diff = [];
-    for (let i = 0; i < oldTable.nodes.length; i++) {
-      const element = oldTable.nodes[i];
-      diff.push(element === newTable.nodes[i]);
-    }
-    const diffCount = diff.reduce((acc, curr) => {
-      if (curr === false) {
-        acc += 1;
-      }
-      return acc;
-    }, 0);
-    return diffCount;
-  };
-
   describe("left rotate", () => {
     test("One node case", () => {
       const pieceTable = constructOneNodePieceTable();
-      const newPieceTable = leftRotate(pieceTable, 1);
-      expect(newPieceTable).toStrictEqual(constructOneNodePieceTable());
-      expect(getDiffCount(pieceTable, newPieceTable)).toBe(0);
+      leftRotate(pieceTable, 1);
+      expect(pieceTable).toStrictEqual(constructOneNodePieceTable());
     });
 
     test("Simple case", () => {
       const pieceTable = constructSimplePieceTableBeforeLeftRotate();
-      const newPieceTable = leftRotate(pieceTable, 2);
-      expect(newPieceTable).toStrictEqual(
+      leftRotate(pieceTable, 2);
+      expect(pieceTable).toStrictEqual(
         constructSimplePieceTableAfterLeftRotate(),
       );
-      expect(getDiffCount(pieceTable, newPieceTable)).toBeLessThanOrEqual(4);
     });
 
     test("Complex case", () => {
       const pieceTable = constructComplexPieceTableBeforeLeftRotate();
-      const newPieceTable = leftRotate(pieceTable, 7);
-      expect(newPieceTable).toStrictEqual(
+      leftRotate(pieceTable, 7);
+      expect(pieceTable).toStrictEqual(
         constructComplexPieceTableAfterLeftRotate(),
       );
-      expect(getDiffCount(pieceTable, newPieceTable)).toBeLessThanOrEqual(4);
     });
   });
 
   describe("right rotate", () => {
     test("One node case", () => {
       const pieceTable = constructOneNodePieceTable();
-      const newPieceTable = rightRotate(pieceTable, 1);
-      expect(newPieceTable).toStrictEqual(constructOneNodePieceTable());
-      expect(getDiffCount(pieceTable, newPieceTable)).toBe(0);
+      rightRotate(pieceTable, 1);
+      expect(pieceTable).toStrictEqual(constructOneNodePieceTable());
     });
 
     test("Simple case", () => {
       const pieceTable = constructSimplePieceTableBeforeRightRotate();
-      const newPieceTable = rightRotate(pieceTable, 4);
-      expect(newPieceTable).toStrictEqual(
+      rightRotate(pieceTable, 4);
+      expect(pieceTable).toStrictEqual(
         constructSimplePieceTableAfterRightRotate(),
       );
-      expect(getDiffCount(pieceTable, newPieceTable)).toBeLessThanOrEqual(4);
     });
 
     test("Complex case", () => {
       const pieceTable = constructComplexPieceTableBeforeRightRotate();
-      const newPieceTable = rightRotate(pieceTable, 11);
-      expect(newPieceTable).toStrictEqual(
+      rightRotate(pieceTable, 11);
+      expect(pieceTable).toStrictEqual(
         constructComplexPieceTableAfterRightRotate(),
       );
-      expect(getDiffCount(pieceTable, newPieceTable)).toBeLessThanOrEqual(4);
     });
   });
 });

--- a/src/page/tree/rotate.ts
+++ b/src/page/tree/rotate.ts
@@ -6,15 +6,12 @@ import { SENTINEL_INDEX } from "./tree";
  * @param page The page/piece table.
  * @param nodeIndex The index of the node in the array for which the left rotation is performed on.
  */
-export function leftRotate(
-  page: PageContentMutable,
-  nodeIndex: number,
-): PageContentMutable {
+export function leftRotate(page: PageContentMutable, nodeIndex: number): void {
   const x = nodeIndex;
 
   if (page.nodes[x].right === SENTINEL_INDEX) {
     //  you can't left rotate
-    return page;
+    return;
   }
 
   page.nodes[x] = { ...page.nodes[x] };
@@ -57,8 +54,6 @@ export function leftRotate(
 
   (page.nodes[y] as NodeMutable).left = x;
   (page.nodes[x] as NodeMutable).parent = y;
-
-  return page;
 }
 
 /**

--- a/src/page/tree/rotate.ts
+++ b/src/page/tree/rotate.ts
@@ -61,15 +61,12 @@ export function leftRotate(page: PageContentMutable, nodeIndex: number): void {
  * @param page The page/piece table.
  * @param nodeIndex The index of the node in the array for which the right rotation is performed on.
  */
-export function rightRotate(
-  page: PageContentMutable,
-  nodeIndex: number,
-): PageContentMutable {
+export function rightRotate(page: PageContentMutable, nodeIndex: number): void {
   const y = nodeIndex;
 
   if (page.nodes[y].left === SENTINEL_INDEX) {
     // you can't right rotate
-    return page;
+    return;
   }
 
   page.nodes[y] = { ...page.nodes[y] };
@@ -109,6 +106,4 @@ export function rightRotate(
 
   page.nodes[y] = page.nodes[y];
   page.nodes[x] = page.nodes[x];
-
-  return page;
 }

--- a/src/page/tree/tree.test.ts
+++ b/src/page/tree/tree.test.ts
@@ -266,7 +266,8 @@ describe("page/tree/tree", () => {
 
   test("Recompute tree metadata: add a node to the end", () => {
     const page = getPage(); // hypothetically added the last node
-    expect(recomputeTreeMetadata(page, 7)).toStrictEqual(getPage());
+    recomputeTreeMetadata(page, 7);
+    expect(page).toStrictEqual(getPage());
   });
 
   test("Recompute tree metadata: add a node in the middle", () => {
@@ -277,8 +278,8 @@ describe("page/tree/tree", () => {
     (expectedPage.nodes[6] as NodeMutable).leftLineFeedCount += 5;
     (expectedPage.nodes[5] as NodeMutable).lineFeedCount += 5;
 
-    const receivedPage = recomputeTreeMetadata(page, 4);
-    expect(receivedPage).toStrictEqual(expectedPage);
+    recomputeTreeMetadata(page, 4);
+    expect(page).toStrictEqual(expectedPage);
   });
 
   test("nextNode", () => {

--- a/src/page/tree/tree.ts
+++ b/src/page/tree/tree.ts
@@ -202,11 +202,11 @@ export function getOffsetInBuffer(
 export function recomputeTreeMetadata(
   page: PageContentMutable,
   x: number,
-): PageContentMutable {
+): void {
   let lengthDelta = 0;
   let lineFeedDelta = 0;
   if (x === page.root) {
-    return page;
+    return;
   }
   page.nodes[x] = { ...page.nodes[x] };
 
@@ -217,7 +217,7 @@ export function recomputeTreeMetadata(
 
   if (x === page.root) {
     // well, it means we add a node to the end (inorder)
-    return page;
+    return;
   }
 
   // page.nodes[x] is the node whose right subtree is changed.
@@ -250,7 +250,7 @@ export function recomputeTreeMetadata(
     page.nodes[x] = { ...page.nodes[x] };
   }
 
-  return page;
+  return;
 }
 
 /**


### PR DESCRIPTION
If a function mutates the returned object, the return type is changed to `void`. 