### PR TITLE
Fixes #52

### DIFF
--- a/src/editor/markdown/markdownEditor.test.tsx
+++ b/src/editor/markdown/markdownEditor.test.tsx
@@ -7,6 +7,9 @@ import { MarkdownEditorComponent } from "./markdownEditor";
 import EditorBaseComponent from "../editorBase";
 
 configure({ adapter: new Adapter() });
+// TODO: Redo when writing tests for the GUI.
+window.getSelection = jest.fn();
+(window.getSelection as jest.Mock).mockReturnValue({ empty: () => undefined });
 
 describe("Markdown output", () => {
   test("Basic text", () => {

--- a/src/editor/markdown/markdownEditor.tsx
+++ b/src/editor/markdown/markdownEditor.tsx
@@ -311,7 +311,7 @@ export function MarkdownEditorComponent(
       const contentOffsetValue = Number(contentOffset.value);
       if (content === "\n") {
         cursorSelection = {
-          nodeIndex: structureNodeIndexValue,
+          nodeIndex: props.page.structure.nodes.length,
           selectionOffset: 0,
         };
         props.splitStructureNode(
@@ -363,6 +363,7 @@ export function MarkdownEditorComponent(
     }
   }
 
+  window.getSelection().empty();
   useEffect(() => {
     if (cursorSelection) {
       const selection = window.getSelection();


### PR DESCRIPTION
Also prevents the cursor from being rendered during the initial draw. It is now only being set by the `useEffect` hook.